### PR TITLE
resolves bug when input dir contains a period

### DIFF
--- a/dtcli/cli.py
+++ b/dtcli/cli.py
@@ -139,7 +139,9 @@ def main():
 
     output_path = os.path.normpath(args.output_path)
     if os.path.isdir(output_path):
-        path_base = os.path.splitext(os.path.basename(t.path))[0]
+        path_base = os.path.basename(t.path)
+        if os.path.isfile(t.path):
+            path_base = os.path.splitext(path_base)[0]
         save_fn = os.path.join(args.output_path, path_base + '.torrent')
     else:
         save_fn = args.output_path


### PR DESCRIPTION
os.path.splitext() should not be used when the input path is a dir. When the dir contains a period, it will be split and the filename for the torrent will be incomplete.